### PR TITLE
Add option to ignore tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+.bundle
+*.gem

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 2.4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,57 +1,10 @@
 require 'rubygems'
-require 'rake/gempackagetask'
-require 'rubygems/specification'
-require 'date'
-require 'spec/rake/spectask'
+require 'rake'
+require 'rspec/core/rake_task'
 
-GEM = "htmldiff"
-GEM_VERSION = "0.0.1"
-AUTHOR = "Nathan Herald"
-EMAIL = "nathan@myobie.com"
-HOMEPAGE = "http://github.com/myobie/htmldiff"
-SUMMARY = "HTML diffs of text (borrowed from a wiki software I no longer remember)"
-
-spec = Gem::Specification.new do |s|
-  s.name = GEM
-  s.version = GEM_VERSION
-  s.platform = Gem::Platform::RUBY
-  s.has_rdoc = true
-  s.extra_rdoc_files = ["README", "LICENSE", 'TODO']
-  s.summary = SUMMARY
-  s.description = s.summary
-  s.author = AUTHOR
-  s.email = EMAIL
-  s.homepage = HOMEPAGE
-  
-  # Uncomment this to add a dependency
-  # s.add_dependency "foo"
-  
-  s.require_path = 'lib'
-  s.autorequire = GEM
-  s.files = %w(LICENSE README Rakefile TODO) + Dir.glob("{lib,spec}/**/*")
+desc "Run RSpec"
+RSpec::Core::RakeTask.new do |t|
+  t.verbose = false
 end
 
 task :default => :spec
-
-desc "Run specs"
-Spec::Rake::SpecTask.new do |t|
-  t.spec_files = FileList['spec/**/*_spec.rb']
-  t.spec_opts = %w(-fs --color)
-end
-
-
-Rake::GemPackageTask.new(spec) do |pkg|
-  pkg.gem_spec = spec
-end
-
-desc "install the gem locally"
-task :install => [:package] do
-  sh %{sudo gem install pkg/#{GEM}-#{GEM_VERSION}}
-end
-
-desc "create a gemspec file"
-task :make_spec do
-  File.open("#{GEM}.gemspec", "w") do |file|
-    file.puts spec.to_ruby
-  end
-end

--- a/htmldiff.gemspec
+++ b/htmldiff.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |s|
   s.rubygems_version = %q{1.3.1}
   s.summary = %q{HTML diffs of text (borrowed from a wiki software I no longer remember)}
 
+  s.add_development_dependency 'rspec', '~> 3.6'
+  s.add_development_dependency 'rake', '~> 12.1'
+
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
     s.specification_version = 2

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -16,9 +16,10 @@ module HTMLDiff
 
   class DiffBuilder
 
-    def initialize(old_version, new_version, ignore_whitespace = false)
+    def initialize(old_version, new_version, ignore_whitespace = false, ignore_tags = false)
       @old_version, @new_version = old_version, new_version
       @ignore_whitespace = ignore_whitespace
+      @ignore_tags = ignore_tags
       @join_char = ignore_whitespace ? ' ' : ''
       @content = []
     end
@@ -210,6 +211,7 @@ module HTMLDiff
         @content << wrap_text(non_tags.join(@join_char), tagname, cssclass) unless non_tags.empty?
 
         break if words.empty?
+        break if @ignore_tags && tagname == "del"
         @content += extract_consecutive_words(words) { |word| tag?(word) }
       end
     end
@@ -291,8 +293,8 @@ module HTMLDiff
 
   end # of class Diff Builder
 
-  def diff(a, b, ignore_whitespace = false)
-    DiffBuilder.new(a, b, ignore_whitespace).build
+  def diff(a, b, ignore_whitespace = false, ignore_tags = false)
+    DiffBuilder.new(a, b, ignore_whitespace, ignore_tags).build
   end
 
 end

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -136,33 +136,9 @@ module HTMLDiff
         match_length_at = new_match_length_at
       end
 
-#      best_match_in_old, best_match_in_new, best_match_size = add_matching_words_left(
-#          best_match_in_old, best_match_in_new, best_match_size, start_in_old, start_in_new)
-#      best_match_in_old, best_match_in_new, match_size = add_matching_words_right(
-#          best_match_in_old, best_match_in_new, best_match_size, end_in_old, end_in_new)
-
       return (best_match_size != 0 ? Match.new(best_match_in_old, best_match_in_new, best_match_size) : nil)
     end
 
-    def add_matching_words_left(match_in_old, match_in_new, match_size, start_in_old, start_in_new)
-      while match_in_old > start_in_old and
-            match_in_new > start_in_new and
-            @old_words[match_in_old - 1] == @new_words[match_in_new - 1]
-        match_in_old -= 1
-        match_in_new -= 1
-        match_size += 1
-      end
-      [match_in_old, match_in_new, match_size]
-    end
-
-    def add_matching_words_right(match_in_old, match_in_new, match_size, end_in_old, end_in_new)
-      while match_in_old + match_size < end_in_old and
-            match_in_new + match_size < end_in_new and
-            @old_words[match_in_old + match_size] == @new_words[match_in_new + match_size]
-        match_size += 1
-      end
-      [match_in_old, match_in_new, match_size]
-    end
 
     VALID_METHODS = [:replace, :insert, :delete, :equal]
 

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -7,34 +7,31 @@ class TestDiff
 end
 
 describe "htmldiff" do
-  
   it "should diff text" do
-    
     diff = TestDiff.diff('a word is here', 'a nother word is there')
-    diff.should == "a<ins class=\"diffins\"> nother</ins> word is <del class=\"diffmod\">here</del><ins class=\"diffmod\">there</ins>"
-    
+    expect(diff).to eq("a<ins class=\"diffins\"> nother</ins> word is <del class=\"diffmod\">here</del><ins class=\"diffmod\">there</ins>")
   end
-  
+
   it "should insert a letter and a space" do
     diff = TestDiff.diff('a c', 'a b c')
-    diff.should == "a <ins class=\"diffins\">b </ins>c"
+    expect(diff).to eq("a <ins class=\"diffins\">b </ins>c")
   end
-  
+
   it "should remove a letter and a space" do
     diff = TestDiff.diff('a b c', 'a c')
-    diff.should == "a <del class=\"diffdel\">b </del>c"
+    expect(diff).to eq("a <del class=\"diffdel\">b </del>c")
   end
-  
+
   it "should change a letter" do
     diff = TestDiff.diff('a b c', 'a d c')
-    diff.should == "a <del class=\"diffmod\">b</del><ins class=\"diffmod\">d</ins> c"
+    expect(diff).to eq("a <del class=\"diffmod\">b</del><ins class=\"diffmod\">d</ins> c")
   end
 
   it "should support Chinese" do
     diff = TestDiff.diff('这个是中文内容, Ruby is the bast', '这是中国语内容，Ruby is the best language.')
-    diff.should == "<del class=\"diffmod\">这个是中文内容, Ruby</del><ins class=\"diffmod\">这是中国语内容，Ruby</ins> is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
+    expect(diff).to eq("<del class=\"diffmod\">这个是中文内容, Ruby</del><ins class=\"diffmod\">这是中国语内容，Ruby</ins> is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>")
   end
-  
+
   it "by default opening tags are duplicated breaking the dom" do
     a = 'a <a href="#c1"></a> b'
     b = 'a <a href="#c2"></a> c'

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -35,4 +35,31 @@ describe "htmldiff" do
     diff.should == "这<del class=\"diffdel\">个</del>是中<del class=\"diffmod\">文</del><ins class=\"diffmod\">国语</ins>内<del class=\"diffmod\">容, Ruby</del><ins class=\"diffmod\">容，Ruby</ins> is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
   end
   
+  it "by default opening tags are duplicated breaking the dom" do
+    a = 'a <a href="#c1"></a> b'
+    b = 'a <a href="#c2"></a> c'
+    diff = TestDiff.diff(a, b)
+    expect(diff).to eq("a <a href=\"#c1\"><a href=\"#c2\"></a> <del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins>")
+  end
+
+  it "changes in properties will render both versions of the start tag, but not end tag" do
+    a = 'a <a href="#c1"></a> b'
+    b = 'a <a href="#c2"></a> c'
+    diff = TestDiff.diff(a, b, false, true)
+    expect(diff).to eq("a <a href=\"#c2\"></a> <del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins>")
+  end
+
+  it "works when jumping between tags and non tags" do
+    a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
+    b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
+    diff = TestDiff.diff(a, b, false, true)
+    expect(diff).to eq("a <a href=\"#c2\"></a><del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins><a href=\"#c3\"> <del class=\"diffmod\">c</del><ins class=\"diffmod\">d</ins><a href=\"#c4\">e")
+  end
+
+  it "example from the library" do
+    a = '<p>a</p>'
+    b = '<p>ab</p><p>c</b>'
+    diff = TestDiff.diff(a, b)
+    expect(diff).to eq("<p><del class=\"diffmod\">a</del><ins class=\"diffmod\">ab</ins></p><p><ins class=\"diffins\">c</ins></b>")
+  end
 end

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -32,7 +32,7 @@ describe "htmldiff" do
 
   it "should support Chinese" do
     diff = TestDiff.diff('这个是中文内容, Ruby is the bast', '这是中国语内容，Ruby is the best language.')
-    diff.should == "这<del class=\"diffdel\">个</del>是中<del class=\"diffmod\">文</del><ins class=\"diffmod\">国语</ins>内<del class=\"diffmod\">容, Ruby</del><ins class=\"diffmod\">容，Ruby</ins> is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
+    diff.should == "<del class=\"diffmod\">这个是中文内容, Ruby</del><ins class=\"diffmod\">这是中国语内容，Ruby</ins> is the <del class=\"diffmod\">bast</del><ins class=\"diffmod\">best language.</ins>"
   end
   
   it "by default opening tags are duplicated breaking the dom" do


### PR DESCRIPTION
By default the library will duplicate opening tags (if attributes are
modified), but not necessarily closing tags, breaking the dom e.g. for
links.

This prevents the tag duplication, which is not relevant for our use
case (rendered diff), but will also not diff e.g. image tags.

https://github.com/karnov/htmldiff/pull/1/commits/530a7aea53cfada21b44f16f939e881afff05eda is the feature change, rest is just meta to make it run in travis cleanly.

NOTE: Attribution is still in the .gemspec, it was duplicated in the Rakefile, and i removed that.