### PR TITLE
Reduce consecutive diffmods to one

### DIFF
--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -1,5 +1,6 @@
 # encoding: UTF-8
 module HTMLDiff
+  SIBLING_ELEMENTS = %w(p li div).freeze
 
   Match = Struct.new(:start_in_old, :start_in_new, :size)
   class Match
@@ -231,7 +232,10 @@ module HTMLDiff
         @content << wrap_text(non_tags.join(@join_char), tagname, cssclass) unless non_tags.empty?
 
         break if words.empty?
-        break if @ignore_tags && tagname == "del"
+        mm = words.first.match(/<\/?(\w+)>/)
+        next_tagname = mm ? mm[1] : nil
+        break if @ignore_tags && tagname == "del" && !SIBLING_ELEMENTS.include?(next_tagname)
+
         @content += extract_consecutive_words(words) { |word| tag?(word) }
       end
     end

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -15,12 +15,27 @@ module HTMLDiff
   Operation = Struct.new(:action, :start_in_old, :end_in_old, :start_in_new, :end_in_new)
 
   class DiffBuilder
-
-    def initialize(old_version, new_version, ignore_whitespace = false, ignore_tags = false)
+    # For BC reasons, you can call this constructor with positioned options, but named are strongly preferred.
+    #
+    # Legacy signature:
+    #   def initialize(old_version, new_version, ignore_whitespace = false, ignore_tags = false)
+    #
+    # New signature:
+    #   def initialize(old_version, new_version, ignore_whitespace: false, ignore_tags: false, reduce_consecutive: false)
+    #
+    def initialize(old_version, new_version, *mixed)
       @old_version, @new_version = old_version, new_version
-      @ignore_whitespace = ignore_whitespace
-      @ignore_tags = ignore_tags
-      @join_char = ignore_whitespace ? ' ' : ''
+      if mixed.first.is_a?(Hash)
+        options = mixed.first
+        @ignore_whitespace = !! options[:ignore_whitespace]
+        @ignore_tags = !! options[:ignore_tags]
+        @reduce_consecutive = !! options[:reduce_consecutive]
+      else
+        @ignore_whitespace = !! mixed[0]
+        @ignore_tags = !! mixed[1]
+        @reduce_consecutive = false
+      end
+      @join_char = @ignore_whitespace ? ' ' : ''
       @content = []
     end
 
@@ -28,7 +43,12 @@ module HTMLDiff
       split_inputs_to_words
       index_new_words
       operations.each { |op| perform_operation(op) }
-      return @content.join(@join_char)
+      diff_output = @content.join(@join_char)
+      if @reduce_consecutive
+        ConsecutiveDiffReducer.new.call(diff_output)
+      else
+        diff_output
+      end
     end
 
     def split_inputs_to_words
@@ -293,8 +313,63 @@ module HTMLDiff
 
   end # of class Diff Builder
 
-  def diff(a, b, ignore_whitespace = false, ignore_tags = false)
-    DiffBuilder.new(a, b, ignore_whitespace, ignore_tags).build
+  class ConsecutiveDiffReducer
+    def initialize(skip: /^\s+$/)
+      @skip_regexp = skip
+    end
+
+    def call(input)
+      token_regexp = /(<del[^>]*>.*?<\/del><ins[^>]*>.*?<\/ins>)/i
+      mode = :none
+      @output = []
+      @buffer = []
+      input.split(token_regexp).each do |token|
+        if token =~ token_regexp
+          flush_buffer! unless mode == :diffmod
+          mode = :diffmod
+          @buffer << token
+        elsif token =~ @skip_regexp && mode == :diffmod
+          @buffer << token
+        else
+          flush_buffer!
+          mode = :none
+          @output << token
+        end
+      end
+      flush_buffer!
+      @output.join
+    end
+
+    def flush_buffer!
+      @output = @output + reduce_buffer
+      @buffer = []
+    end
+
+    def reduce_buffer
+      return [] if @buffer.empty?
+      delete_tag = nil
+      insert_tag = nil
+      deletes = []
+      inserts = []
+      @buffer.each do |token|
+        if token =~ @skip_regexp
+          deletes << token
+          inserts << token
+        else
+          m = token.match(/(<del[^>]*>)(.*?)<\/del>(<ins[^>]*>)(.*?)<\/ins>/i)
+          fail "Token didn't match expression" unless m
+          delete_tag ||= m[1]
+          deletes << m[2]
+          insert_tag ||= m[3]
+          inserts << m[4]
+        end
+      end
+      [delete_tag, *deletes, "</del>", insert_tag, *inserts, "</ins>"]
+    end
+  end # of class ConsecutiveDiffReducer
+
+  def diff(a, b, *options)
+    DiffBuilder.new(a, b, *options).build
   end
 
 end

--- a/lib/htmldiff.rb
+++ b/lib/htmldiff.rb
@@ -1,6 +1,5 @@
 # encoding: UTF-8
 module HTMLDiff
-  SIBLING_ELEMENTS = %w(p li div).freeze
 
   Match = Struct.new(:start_in_old, :start_in_new, :size)
   class Match
@@ -26,11 +25,13 @@ module HTMLDiff
     #
     def initialize(old_version, new_version, *mixed)
       @old_version, @new_version = old_version, new_version
+      @sibling_elements = %w(p li div)
       if mixed.first.is_a?(Hash)
         options = mixed.first
         @ignore_whitespace = !! options[:ignore_whitespace]
         @ignore_tags = !! options[:ignore_tags]
         @reduce_consecutive = !! options[:reduce_consecutive]
+        @sibling_elements = options[:sibling_elements] if options[:sibling_elements]
       else
         @ignore_whitespace = !! mixed[0]
         @ignore_tags = !! mixed[1]
@@ -234,7 +235,7 @@ module HTMLDiff
         break if words.empty?
         mm = words.first.match(/<\/?(\w+)>/)
         next_tagname = mm ? mm[1] : nil
-        break if @ignore_tags && tagname == "del" && !SIBLING_ELEMENTS.include?(next_tagname)
+        break if @ignore_tags && tagname == "del" && !@sibling_elements.include?(next_tagname)
 
         @content += extract_consecutive_words(words) { |word| tag?(word) }
       end

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -48,38 +48,78 @@ describe "htmldiff" do
 
   describe "ignore_tags option" do
     describe "changes in properties should render balanced tags" do
-      it "will render both versions of the start tag, but not end tag when disabled" do
-        a = 'a <a href="#c1"></a> b'
-        b = 'a <a href="#c2"></a> c'
-        expected = 'a <a href="#c1"><a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
-        diff = TestDiff.diff(a, b, ignore_tags: false)
-        expect(diff).to eq(expected)
+      describe "when disabled" do
+        it "will render both versions of the start tag, but not end tag" do
+          a = 'a <a href="#c1"></a> b'
+          b = 'a <a href="#c2"></a> c'
+          expected = 'a <a href="#c1"><a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
+          diff = TestDiff.diff(a, b, ignore_tags: false)
+          expect(diff).to eq(expected)
+        end
+
+        it "will render both versions of the start tag, but not end tag" do
+          a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
+          b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
+          expected = 'a <a href="#c1"><a href="#c2"></a><del class="diffmod">b</del><a href="#c1"><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><a href="#c1"><ins class="diffmod">d</ins><a href="#c4">e'
+          diff = TestDiff.diff(a, b, ignore_tags: false)
+          expect(diff).to eq(expected)
+        end
       end
 
-      it "will produce valid html when enabled" do
-        a = 'a <a href="#c1"></a> b'
-        b = 'a <a href="#c2"></a> c'
-        expected = 'a <a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
-        diff = TestDiff.diff(a, b, ignore_tags: true)
-        expect(diff).to eq(expected)
+      describe "when enabled" do
+        it "will produce valid html" do
+          a = 'a <a href="#c1"></a> b'
+          b = 'a <a href="#c2"></a> c'
+          expected = 'a <a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
+          diff = TestDiff.diff(a, b, ignore_tags: true)
+          expect(diff).to eq(expected)
+        end
+
+        it "will produce valid html" do
+          a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
+          b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
+          expected = 'a <a href="#c2"></a><del class="diffmod">b</del><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><ins class="diffmod">d</ins><a href="#c4">e'
+          diff = TestDiff.diff(a, b, ignore_tags: true)
+          expect(diff).to eq(expected)
+        end
       end
     end
 
-    describe "when jumping between tags and non tags" do
-      it "will render both versions of the start tag, but not end tag when disabled" do
-        a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
-        b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
-        expected = 'a <a href="#c1"><a href="#c2"></a><del class="diffmod">b</del><a href="#c1"><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><a href="#c1"><ins class="diffmod">d</ins><a href="#c4">e'
-        diff = TestDiff.diff(a, b, ignore_tags: false)
-        expect(diff).to eq(expected)
+    describe "removing tag with similar siblings" do
+      describe "when disabled" do
+        it "should show deleted paragraph" do
+          a = '<p>first</p><p>second</p>'
+          b = '<p>first</p>'
+          expected = '<p>first</p><p><del class="diffdel">second</del></p>'
+          diff = TestDiff.diff(a, b, ignore_tags: false)
+          expect(diff).to eq(expected)
+        end
+
+        it "should show deleted list-element" do
+          a = 'my list <ol><li>item a</li><li>item b</li></ol>'
+          b = 'my list <ol><li>item a</li></ol>'
+          expected = 'my list <ol><li>item a</li><li><del class="diffdel">item b</del></li></ol>'
+          diff = TestDiff.diff(a, b, ignore_tags: false)
+          expect(diff).to eq(expected)
+        end
       end
 
-      it "will produce valid html when enabled" do
-        a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
-        b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
-        expected = 'a <a href="#c2"></a><del class="diffmod">b</del><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><ins class="diffmod">d</ins><a href="#c4">e'
-        diff = TestDiff.diff(a, b, ignore_tags: true)
-        expect(diff).to eq(expected)
+      describe "when enabled" do
+        it "should show deleted paragraph" do
+          a = '<p>first</p><p>second</p>'
+          b = '<p>first</p>'
+          expected = '<p>first</p><p><del class="diffdel">second</del></p>'
+          diff = TestDiff.diff(a, b, ignore_tags: true)
+          expect(diff).to eq(expected)
+        end
+
+        it "should show deleted list-element" do
+          a = 'my list <ol><li>item a</li><li>item b</li></ol>'
+          b = 'my list <ol><li>item a</li></ol>'
+          expected = 'my list <ol><li>item a</li><li><del class="diffdel">item b</del></li></ol>'
+          diff = TestDiff.diff(a, b, ignore_tags: true)
+          expect(diff).to eq(expected)
+        end
       end
     end
   end

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -39,20 +39,6 @@ describe "htmldiff" do
     expect(diff).to eq("a <a href=\"#c1\"><a href=\"#c2\"></a> <del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins>")
   end
 
-  it "changes in properties will render both versions of the start tag, but not end tag" do
-    a = 'a <a href="#c1"></a> b'
-    b = 'a <a href="#c2"></a> c'
-    diff = TestDiff.diff(a, b, false, true)
-    expect(diff).to eq("a <a href=\"#c2\"></a> <del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins>")
-  end
-
-  it "works when jumping between tags and non tags" do
-    a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
-    b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
-    diff = TestDiff.diff(a, b, false, true)
-    expect(diff).to eq("a <a href=\"#c2\"></a><del class=\"diffmod\">b</del><ins class=\"diffmod\">c</ins><a href=\"#c3\"> <del class=\"diffmod\">c</del><ins class=\"diffmod\">d</ins><a href=\"#c4\">e")
-  end
-
   it "example from the library" do
     a = '<p>a</p>'
     b = '<p>ab</p><p>c</b>'
@@ -60,11 +46,59 @@ describe "htmldiff" do
     expect(diff).to eq("<p><del class=\"diffmod\">a</del><ins class=\"diffmod\">ab</ins></p><p><ins class=\"diffins\">c</ins></b>")
   end
 
-  it "should reduce consecutive matches" do
-    a = '<p>Han går til samtaler ved en psykiater. Like a boss.</p>'
-    b = '<p>Han drikker stærk spiritus. Like a boss.</p>'
-    expected = '<p>Han <del class="diffmod">går til samtaler ved en psykiater.</del><ins class="diffmod">drikker stærk spiritus.</ins> Like a boss.</p>'
-    diff = TestDiff.diff(a, b, reduce_consecutive: true)
-    expect(diff).to eq(expected)
+  describe "ignore_tags option" do
+    describe "changes in properties should render balanced tags" do
+      it "will render both versions of the start tag, but not end tag when disabled" do
+        a = 'a <a href="#c1"></a> b'
+        b = 'a <a href="#c2"></a> c'
+        expected = 'a <a href="#c1"><a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
+        diff = TestDiff.diff(a, b, ignore_tags: false)
+        expect(diff).to eq(expected)
+      end
+
+      it "will produce valid html when enabled" do
+        a = 'a <a href="#c1"></a> b'
+        b = 'a <a href="#c2"></a> c'
+        expected = 'a <a href="#c2"></a> <del class="diffmod">b</del><ins class="diffmod">c</ins>'
+        diff = TestDiff.diff(a, b, ignore_tags: true)
+        expect(diff).to eq(expected)
+      end
+    end
+
+    describe "when jumping between tags and non tags" do
+      it "will render both versions of the start tag, but not end tag when disabled" do
+        a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
+        b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
+        expected = 'a <a href="#c1"><a href="#c2"></a><del class="diffmod">b</del><a href="#c1"><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><a href="#c1"><ins class="diffmod">d</ins><a href="#c4">e'
+        diff = TestDiff.diff(a, b, ignore_tags: false)
+        expect(diff).to eq(expected)
+      end
+
+      it "will produce valid html when enabled" do
+        a = 'a <a href="#c1"></a>b<a href="#c1"> c<a href="#c1">e'
+        b = 'a <a href="#c2"></a>c<a href="#c3"> d<a href="#c4">e'
+        expected = 'a <a href="#c2"></a><del class="diffmod">b</del><ins class="diffmod">c</ins><a href="#c3"> <del class="diffmod">c</del><ins class="diffmod">d</ins><a href="#c4">e'
+        diff = TestDiff.diff(a, b, ignore_tags: true)
+        expect(diff).to eq(expected)
+      end
+    end
+  end
+
+  describe "reduce_consecutive option" do
+    it "should diff individual words, when not enabled" do
+      a = '<p>Han går til samtaler ved en psykiater. Like a boss.</p>'
+      b = '<p>Han drikker stærk spiritus. Like a boss.</p>'
+      expected = '<p>Han <del class="diffmod">går</del><ins class="diffmod">drikker</ins> <del class="diffmod">til</del><ins class="diffmod">stærk</ins> <del class="diffmod">samtaler ved en psykiater.</del><ins class="diffmod">spiritus.</ins> Like a boss.</p>'
+      diff = TestDiff.diff(a, b, reduce_consecutive: false)
+      expect(diff).to eq(expected)
+    end
+
+    it "should reduce consecutive matches, when enabled" do
+      a = '<p>Han går til samtaler ved en psykiater. Like a boss.</p>'
+      b = '<p>Han drikker stærk spiritus. Like a boss.</p>'
+      expected = '<p>Han <del class="diffmod">går til samtaler ved en psykiater.</del><ins class="diffmod">drikker stærk spiritus.</ins> Like a boss.</p>'
+      diff = TestDiff.diff(a, b, reduce_consecutive: true)
+      expect(diff).to eq(expected)
+    end
   end
 end

--- a/spec/htmldiff_spec.rb
+++ b/spec/htmldiff_spec.rb
@@ -59,4 +59,12 @@ describe "htmldiff" do
     diff = TestDiff.diff(a, b)
     expect(diff).to eq("<p><del class=\"diffmod\">a</del><ins class=\"diffmod\">ab</ins></p><p><ins class=\"diffins\">c</ins></b>")
   end
+
+  it "should reduce consecutive matches" do
+    a = '<p>Han går til samtaler ved en psykiater. Like a boss.</p>'
+    b = '<p>Han drikker stærk spiritus. Like a boss.</p>'
+    expected = '<p>Han <del class="diffmod">går til samtaler ved en psykiater.</del><ins class="diffmod">drikker stærk spiritus.</ins> Like a boss.</p>'
+    diff = TestDiff.diff(a, b, reduce_consecutive: true)
+    expect(diff).to eq(expected)
+  end
 end


### PR DESCRIPTION
Makes for a prettier output. I made the feature be opt-in to not break any existing code, but most users would probably benefit from enabling it. I also changed the constructor signature to use named parameters, but retained BC.